### PR TITLE
npm install failing, nomnom 2.0.0 not found, nomnom is deprecated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2164,6 +2164,11 @@
         "isarray": "0.0.1"
       }
     },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+    },
     "has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
@@ -2833,9 +2838,35 @@
       "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
     },
     "nomnom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-2.0.0.tgz",
-      "integrity": "sha512-frks+w18/6p+nAJ+zd6DdPpBytjt4tdTVnRY9nK4GoiCtG4gVgLs4MR+LCm83Bq4JtN6ol7a10BSPsS/qE+2dA=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+      "requires": {
+        "chalk": "~0.4.0",
+        "underscore": "~1.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+          "requires": {
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+        }
+      }
     },
     "nopt": {
       "version": "3.0.6",
@@ -4644,6 +4675,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
     },
     "underscore.string": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "request": "^2.75.0",
     "sails": "~0.12.4",
     "sails-disk": "~0.10.9",
-    "sails-hook-pagify": "^0.2.0"
+    "sails-hook-pagify": "^0.2.0",
+    "nomnom": "<2.0.0"
   }
 }


### PR DESCRIPTION
npm install was failing:
npm ERR! 404 Not Found: nomnom@2.0.0

jsonlint is picking up the deprecation placeholder. https://github.com/zaach/jsonlint/issues/103